### PR TITLE
DP-8085 - Migrate to Semaphore self-hosted agent

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,8 +2,7 @@ version: v1.0
 name: go-ps1
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
+    type: s1-prod-ubuntu20-04-amd64-1
 blocks:
   - name: "Build, Test, Release"
     task:


### PR DESCRIPTION
# Background
In the current Semaphore cloud offering, all of the Semaphore build nodes are controlled by Semaphore. Thus, we are unable to control what resources they can access. 
It also represents security concerns because Semaphore has access to what is on those nodes, including our credentials from Vault.
The DevProd team will be migrating the existing SemaphoreCI pipelines using linux machines to start using self-hosted Semaphore build agents.
Deadline to migrate the SemaphoreCI jobs to self hosted agents is July 22nd, 2022
The DevProd team will start creating PRs to migrate your existing Semaphore jobs to the self-hosted agents by July 10, 2022.

**This migrates to Semaphore self-hosted agent**

# Changelog
Details on the self-hosted agent host configuration are described here : https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2820542346/Semaphore+Self+Hosted+Agents

# Migration Changes
This automated pull request changes
* Pipeline YAML files under .semaphore folder

# Actions
* If you are happy with the changes, feel free to merge.
* If you have concerns about the changes, comment on this pull request, tagging the Developer Productivity team `(@confluentinc/tools)`.
* If you happen to have time to look at any of the failures and can help us out, that would be greatly appreciated.
* If the CI does not pass, we may fix some simpler issues on this pull request, but if there is a deeper problem associated with the migration, we may create a task for your team to fix.
