### PR TITLE
[DP-19090] Migrate Windows CI job from Windows 2019 to Windows 2025

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -52,7 +52,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-windows
+          type: s1-windows-2025-amd64-4
       jobs:
         - name: windows/amd64
           commands:


### PR DESCRIPTION
### Change Description
Migrates the Windows job from `s1-prod-windows` (Windows Server 2019) to `s1-windows-2025-amd64-4` (Windows Server 2025) as part of the org-wide rollout of the new Windows 2025 build agent pool.

Why this is the right change:
- Windows Server 2019 is approaching end of mainstream support; standardizing CI on Windows Server 2025 gets us off an aging OS and onto the supported baseline.
- The `s1-windows-2025-amd64-4` pool is already provisioned and has been validated in the [semaphore-test canary](https://github.com/confluentinc/semaphore-test/pull/76).
- See the rollout announcement: https://confluent.slack.com/archives/C038ZJ00P/p1771984127572579

Why this is safe:
- Only `agent.machine.type` changes; no commands, no job structure, no toolchain pinning is modified.
- The Windows job builds Go from the upstream `go.dev` zip (pinned via `.go-version`), so the runtime is not tied to the host OS image.
- If the new pool surfaces a regression, reverting this single-line change restores the previous behavior immediately.

### Testing
- Diff is a single-line agent type swap; no other YAML changed.
- Will be exercised by the next push/PR build on this branch — verify the Windows job picks up the new pool and the build/test step still passes.
