### PR TITLE
[DP-19090] Fix windows/amd64 CI: add GOPATH bin dir to PATH so gotestsum resolves

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -63,7 +63,7 @@ blocks:
             - Expand-Archive Go.zip -DestinationPath C:\
             - $Env:PATH = "C:\Go\bin;$Env:PATH"
             - go install gotest.tools/gotestsum@v1.8.2
-            - gotestsum --junitfile test-report.xml -- -v ./...
+            - '& "$Env:USERPROFILE\go\bin\gotestsum.exe" --junitfile test-report.xml -- -v ./...'
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,8 +61,9 @@ blocks:
             # Do not install Go with Chocolatey since it is community maintained and may not have the latest version
             - Invoke-WebRequest -OutFile Go.zip -Uri https://go.dev/dl/go$(Get-Content .go-version).windows-amd64.zip -UseBasicParsing
             - Expand-Archive Go.zip -DestinationPath C:\
-            - $Env:PATH = "C:\Go\bin;$Env:USERPROFILE\go\bin;$Env:PATH"
+            - $Env:PATH = "C:\Go\bin;$Env:PATH"
             - go install gotest.tools/gotestsum@v1.8.2
+            - $Env:PATH = "$(go env GOPATH)\bin;$Env:PATH"
             - gotestsum --junitfile test-report.xml -- -v ./...
       epilogue:
         always:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,9 +61,9 @@ blocks:
             # Do not install Go with Chocolatey since it is community maintained and may not have the latest version
             - Invoke-WebRequest -OutFile Go.zip -Uri https://go.dev/dl/go$(Get-Content .go-version).windows-amd64.zip -UseBasicParsing
             - Expand-Archive Go.zip -DestinationPath C:\
-            - $Env:PATH = "C:\Go\bin;$Env:PATH"
+            - $Env:PATH = "C:\Go\bin;$Env:USERPROFILE\go\bin;$Env:PATH"
             - go install gotest.tools/gotestsum@v1.8.2
-            - '& "$Env:USERPROFILE\go\bin\gotestsum.exe" --junitfile test-report.xml -- -v ./...'
+            - gotestsum --junitfile test-report.xml -- -v ./...
       epilogue:
         always:
           commands:


### PR DESCRIPTION
### Change Description
Restores Windows CI for `go-ps1`. The `windows/amd64` job has been failing on `main` since 2026-03-13 with:

```
gotestsum : The term 'gotestsum' is not recognized as the name of a cmdlet, function, script file, or operable program.
```

Failed `main` run for reference: https://semaphore.ci.confluent.io/jobs/99084d96-288f-4ffe-a333-14060db94344

Root cause:
- The job runs `go install gotest.tools/gotestsum@v1.8.2`, which writes `gotestsum.exe` to `$Env:USERPROFILE\go\bin` (the default Windows `GOPATH/bin`).
- That directory is not on `PATH`. The existing PATH prepend (`$Env:PATH = "C:\Go\bin;$Env:PATH"`) only handles the Go toolchain itself, not the install destination.
- As a result the subsequent bare `gotestsum` call cannot resolve the binary.

Fix: extend the existing `PATH` prepend on line 64 to also include `$Env:USERPROFILE\go\bin`. This matches the convention the file already uses (rather than introducing a different pattern like full-path invocation) and is a single-line additive change.

### Testing
- The fix branch's Windows job will exercise the new PATH on PR CI; expected to pass through to `gotestsum --junitfile test-report.xml -- -v ./...`.
- No effect on linux/amd64 or darwin/arm64 blocks.
- Once merged, `main` should go green on Windows again.
